### PR TITLE
Added alternative AnimatedText where:

### DIFF
--- a/Sources/TCAnimatedText/AnimatedText.swift
+++ b/Sources/TCAnimatedText/AnimatedText.swift
@@ -27,12 +27,15 @@ public struct AnimatedText: View {
     }
     
     public var body: some View {
-        HStack(alignment: .center, spacing: 0) {
-            ForEach(Array(string.enumerated()), id: \.0) { (n, ch) in
-                self.textModifier(Text(String(ch)))
-                
-            }
-        }.onChange(of: input) { newValue in
+        textView
+        
+//        HStack(alignment: .center, spacing: 0) {
+//            ForEach(Array(string.enumerated()), id: \.0) { (n, ch) in
+//                self.textModifier(Text(String(ch)))
+//
+//            }
+//        }
+        .onChange(of: input) { newValue in
             if self.string != newValue && !self.isUpdating{
                 self.nextValue = newValue
                 self.isUpdating = true
@@ -45,6 +48,15 @@ public struct AnimatedText: View {
                 animateStringChange(newValue: newValue)
             }
         }
+    }
+    
+    var textView: Text {
+        let text = string
+            .enumerated()
+            .map { _, ch in Text(String(ch)) }
+            .reduce(Text(""), +)
+        
+        return textModifier(text)
     }
     
     func animateStringChange(newValue: String) {

--- a/TCAnimatedTextExample/TCAnimatedTextExample.xcodeproj/project.pbxproj
+++ b/TCAnimatedTextExample/TCAnimatedTextExample.xcodeproj/project.pbxproj
@@ -1,0 +1,341 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		80C8333D26254B42003345E9 /* TCAnimatedTextExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C8333C26254B42003345E9 /* TCAnimatedTextExampleApp.swift */; };
+		80C8334126254B43003345E9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 80C8334026254B43003345E9 /* Assets.xcassets */; };
+		80C8334426254B43003345E9 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 80C8334326254B43003345E9 /* Preview Assets.xcassets */; };
+		80C8335126254BAF003345E9 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C8335026254BAF003345E9 /* ContentView.swift */; };
+		80C8335526254C3E003345E9 /* LibraryContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C8335326254C3E003345E9 /* LibraryContent.swift */; };
+		80C8335626254C3E003345E9 /* AnimatedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C8335426254C3E003345E9 /* AnimatedText.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		80C8333926254B42003345E9 /* TCAnimatedTextExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TCAnimatedTextExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		80C8333C26254B42003345E9 /* TCAnimatedTextExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCAnimatedTextExampleApp.swift; sourceTree = "<group>"; };
+		80C8334026254B43003345E9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		80C8334326254B43003345E9 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		80C8334526254B43003345E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		80C8335026254BAF003345E9 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		80C8335326254C3E003345E9 /* LibraryContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LibraryContent.swift; path = ../../Sources/TCAnimatedText/LibraryContent.swift; sourceTree = "<group>"; };
+		80C8335426254C3E003345E9 /* AnimatedText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AnimatedText.swift; path = ../../Sources/TCAnimatedText/AnimatedText.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		80C8333626254B42003345E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		80C8333026254B41003345E9 = {
+			isa = PBXGroup;
+			children = (
+				80C8333B26254B42003345E9 /* TCAnimatedTextExample */,
+				80C8333A26254B42003345E9 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		80C8333A26254B42003345E9 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				80C8333926254B42003345E9 /* TCAnimatedTextExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		80C8333B26254B42003345E9 /* TCAnimatedTextExample */ = {
+			isa = PBXGroup;
+			children = (
+				80C8333C26254B42003345E9 /* TCAnimatedTextExampleApp.swift */,
+				80C8335026254BAF003345E9 /* ContentView.swift */,
+				80C8335426254C3E003345E9 /* AnimatedText.swift */,
+				80C8335326254C3E003345E9 /* LibraryContent.swift */,
+				80C8334026254B43003345E9 /* Assets.xcassets */,
+				80C8334526254B43003345E9 /* Info.plist */,
+				80C8334226254B43003345E9 /* Preview Content */,
+			);
+			path = TCAnimatedTextExample;
+			sourceTree = "<group>";
+		};
+		80C8334226254B43003345E9 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				80C8334326254B43003345E9 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		80C8333826254B42003345E9 /* TCAnimatedTextExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 80C8334826254B43003345E9 /* Build configuration list for PBXNativeTarget "TCAnimatedTextExample" */;
+			buildPhases = (
+				80C8333526254B42003345E9 /* Sources */,
+				80C8333626254B42003345E9 /* Frameworks */,
+				80C8333726254B42003345E9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TCAnimatedTextExample;
+			productName = TCAnimatedTextExample;
+			productReference = 80C8333926254B42003345E9 /* TCAnimatedTextExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		80C8333126254B41003345E9 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1240;
+				LastUpgradeCheck = 1240;
+				TargetAttributes = {
+					80C8333826254B42003345E9 = {
+						CreatedOnToolsVersion = 12.4;
+					};
+				};
+			};
+			buildConfigurationList = 80C8333426254B41003345E9 /* Build configuration list for PBXProject "TCAnimatedTextExample" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 80C8333026254B41003345E9;
+			productRefGroup = 80C8333A26254B42003345E9 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				80C8333826254B42003345E9 /* TCAnimatedTextExample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		80C8333726254B42003345E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				80C8334426254B43003345E9 /* Preview Assets.xcassets in Resources */,
+				80C8334126254B43003345E9 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		80C8333526254B42003345E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				80C8335126254BAF003345E9 /* ContentView.swift in Sources */,
+				80C8335626254C3E003345E9 /* AnimatedText.swift in Sources */,
+				80C8335526254C3E003345E9 /* LibraryContent.swift in Sources */,
+				80C8333D26254B42003345E9 /* TCAnimatedTextExampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		80C8334626254B43003345E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		80C8334726254B43003345E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		80C8334926254B43003345E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"TCAnimatedTextExample/Preview Content\"";
+				DEVELOPMENT_TEAM = 2KMN827G7Y;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = TCAnimatedTextExample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.DandyLyons.TCAnimatedTextExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		80C8334A26254B43003345E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"TCAnimatedTextExample/Preview Content\"";
+				DEVELOPMENT_TEAM = 2KMN827G7Y;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = TCAnimatedTextExample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.DandyLyons.TCAnimatedTextExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		80C8333426254B41003345E9 /* Build configuration list for PBXProject "TCAnimatedTextExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				80C8334626254B43003345E9 /* Debug */,
+				80C8334726254B43003345E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		80C8334826254B43003345E9 /* Build configuration list for PBXNativeTarget "TCAnimatedTextExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				80C8334926254B43003345E9 /* Debug */,
+				80C8334A26254B43003345E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 80C8333126254B41003345E9 /* Project object */;
+}

--- a/TCAnimatedTextExample/TCAnimatedTextExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/TCAnimatedTextExample/TCAnimatedTextExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/TCAnimatedTextExample/TCAnimatedTextExample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/TCAnimatedTextExample/TCAnimatedTextExample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/TCAnimatedTextExample/TCAnimatedTextExample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/TCAnimatedTextExample/TCAnimatedTextExample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TCAnimatedTextExample/TCAnimatedTextExample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/TCAnimatedTextExample/TCAnimatedTextExample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TCAnimatedTextExample/TCAnimatedTextExample/Assets.xcassets/Contents.json
+++ b/TCAnimatedTextExample/TCAnimatedTextExample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TCAnimatedTextExample/TCAnimatedTextExample/ContentView.swift
+++ b/TCAnimatedTextExample/TCAnimatedTextExample/ContentView.swift
@@ -1,0 +1,50 @@
+//
+//  ContentView.swift
+//  TCAnimatedTextExample
+//
+//  Created by Daniel Lyons on 4/12/21.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    @State var input: String = "Hello"
+//    let strings = ["California", "Californication", "Cauliflower", "Cancun", "Calcutta", "Chupacabra"]
+    let strings = ["10:01 at the movie theater", "Will you meet me at 10:01?", "10:01", "The beach is the place. 10:01 is the time", "I will see you at 10:01"]
+//    let strings = ["10:01 at the movie theater Will you meet me at 10:01? 10:01", "The beach is the place. 10:01 is the time I will see you at 10:01"]
+    
+    let question: [Text] =  [
+        Text("Will "),
+        Text("you "),
+        Text("meet "),
+        Text("me "),
+        Text("at "),
+        Text("the "),
+        Text("beach "),
+        Text("at "),
+        Text("10:01?")
+        ]
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            AnimatedText($input, charDuration: 0.05) { text in
+                text
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .foregroundColor(.green)
+            }
+            
+            Button("Change text") { input = strings.randomElement() ?? "nil"}
+            .font(.largeTitle)
+            .foregroundColor(.orange)
+                
+        }
+        .frame(width: 200)
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/TCAnimatedTextExample/TCAnimatedTextExample/Info.plist
+++ b/TCAnimatedTextExample/TCAnimatedTextExample/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/TCAnimatedTextExample/TCAnimatedTextExample/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/TCAnimatedTextExample/TCAnimatedTextExample/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TCAnimatedTextExample/TCAnimatedTextExample/TCAnimatedTextExampleApp.swift
+++ b/TCAnimatedTextExample/TCAnimatedTextExample/TCAnimatedTextExampleApp.swift
@@ -1,0 +1,17 @@
+//
+//  TCAnimatedTextExampleApp.swift
+//  TCAnimatedTextExample
+//
+//  Created by Daniel Lyons on 4/12/21.
+//
+
+import SwiftUI
+
+@main
+struct TCAnimatedTextExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
Hi. I read your article at https://trailingclosure.com/animated-text-package/ and loved it. 

I cloned it and played with it and noticed that if the text is too wide for the frame then the HStack forces each letter to overlap each other. (In other words AnimatedText() loses Text()'s ability to word wrap into additional lines. 

But if you ditch the HStack and instead combine each Text() using the + operator then SwiftUI considers it to be only one Text() (instead of an HStack holding a ForEach holding a bunch of Text() ). 

In other words, if you use the + operator then you regain word wrapping and anything else a native Text() can do. Anyways, I thought you might like to play around with this alternative implementation idea and see if you like it. 

Unfortunately, my implementation appears to be less stable than yours. Maybe you can find a way to make it more stable. 